### PR TITLE
Update prismatic/schema to 0.3.5 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
                  [com.draines/postal "1.11.3"]
                  [version-clj "0.1.2"]
                  [clojurewerkz/quartzite "2.0.0"]
-                 [prismatic/schema "0.3.4"]
+                 [prismatic/schema "0.3.5"]
                  [com.stuartsierra/component "0.2.2"]
                  [me.raynes/fs "1.4.6"]
                  [com.googlecode.streamflyer/streamflyer-core "1.1.3"]


### PR DESCRIPTION
prismatic/schema 0.3.5 has been released. 

This pull request is created on behalf of @nbeloglazov
