### PR TITLE
Update org.clojure/clojurescript to 0.0-2755 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
                  [commons-io "2.4"]
 
                  ; ClojureScript
-                 [org.clojure/clojurescript "0.0-2740"]
+                 [org.clojure/clojurescript "0.0-2755"]
                  [jayq "2.5.2"]
                  [org.omcljs/om "0.8.7"]]
 


### PR DESCRIPTION
org.clojure/clojurescript 0.0-2755 has been released. 

This pull request is created on behalf of @nbeloglazov
