### PR TITLE
Update org.seleniumhq.selenium/selenium-java to 2.45.0 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -42,7 +42,7 @@
   {:dev {:dependencies [[javax.servlet/servlet-api "2.5"]
                         [ring-mock "0.1.5"]
                         [com.cemerick/piggieback "0.1.5"]
-                        [org.seleniumhq.selenium/selenium-java "2.44.0"]
+                        [org.seleniumhq.selenium/selenium-java "2.45.0"]
                         [org.seleniumhq.selenium/selenium-remote-driver "2.44.0"]
                         [org.seleniumhq.selenium/selenium-server "2.44.0"]]
 


### PR DESCRIPTION
org.seleniumhq.selenium/selenium-java 2.45.0 has been released. 

This pull request is created on behalf of @nbeloglazov
