### PR TITLE
Update clj-http to 1.1.0 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [compojure "1.3.1"]
                  [hiccup "1.0.5"]
                  [ring/ring-json "0.3.1"]
-                 [clj-http "1.0.1"]
+                 [clj-http "1.1.0"]
                  [tentacles "0.3.0"]
                  [com.taoensso/timbre "3.4.0"]
                  [com.novemberain/monger "2.0.1"]


### PR DESCRIPTION
clj-http 1.1.0 has been released. 

This pull request is created on behalf of @nbeloglazov
