### PR TITLE
Update org.clojure/clojurescript to 0.0-3165 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
                  [commons-io "2.4"]
 
                  ; ClojureScript
-                 [org.clojure/clojurescript "0.0-3153"]
+                 [org.clojure/clojurescript "0.0-3165"]
                  [jayq "2.5.4"]
                  [org.omcljs/om "0.8.8"]]
 


### PR DESCRIPTION
org.clojure/clojurescript 0.0-3165 has been released. 

This pull request is created on behalf of @nbeloglazov
