### PR TITLE
Update ancient-clj to 0.3.9 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                  [tentacles "0.3.0"]
                  [com.taoensso/timbre "3.4.0"]
                  [com.novemberain/monger "2.0.1"]
-                 [ancient-clj "0.3.8"]
+                 [ancient-clj "0.3.9"]
                  [com.draines/postal "1.11.3"]
                  [version-clj "0.1.2"]
                  [clojurewerkz/quartzite "2.0.0"]


### PR DESCRIPTION
ancient-clj 0.3.9 has been released. 

This pull request is created on behalf of @nbeloglazov
