### PR TITLE
Update ring to 1.4.0-beta2 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "http://hatnik.com"
   :dependencies [; Clojure
                  [org.clojure/clojure "1.7.0-beta2"]
-                 [ring "1.4.0-beta1"]
+                 [ring "1.4.0-beta2"]
                  [compojure "1.3.4"]
                  [hiccup "1.0.5"]
                  [ring/ring-json "0.3.1"]


### PR DESCRIPTION
ring 1.4.0-beta2 has been released. 

This pull request is created on behalf of @nbeloglazov
