### PR TITLE
Update com.taoensso/timbre to 4.0.0-beta4 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  [ring/ring-json "0.3.1"]
                  [clj-http "1.1.2"]
                  [tentacles "0.3.0"]
-                 [com.taoensso/timbre "4.0.0-beta2"]
+                 [com.taoensso/timbre "4.0.0-beta4"]
                  [com.novemberain/monger "2.0.1"]
                  [ancient-clj "0.3.9"]
                  [com.draines/postal "1.11.3"]


### PR DESCRIPTION
com.taoensso/timbre 4.0.0-beta4 has been released. 

This pull request is created on behalf of @nbeloglazov
