### PR TITLE
Update com.taoensso/timbre to 4.1.0-alpha1 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  [ring/ring-json "0.3.1"]
                  [clj-http "1.1.2"]
                  [tentacles "0.4.0"]
-                 [com.taoensso/timbre "4.0.2"]
+                 [com.taoensso/timbre "4.1.0-alpha1"]
                  [com.novemberain/monger "3.0.0-rc2"]
                  [ancient-clj "0.3.9"]
                  [com.draines/postal "1.11.3"]


### PR DESCRIPTION
com.taoensso/timbre 4.1.0-alpha1 has been released. 

This pull request is created on behalf of @nbeloglazov
