### PR TITLE
Update org.seleniumhq.selenium/selenium-remote-driver to 2.47.1 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -43,7 +43,7 @@
                         [ring-mock "0.1.5"]
                         [com.cemerick/piggieback "0.2.1"]
                         [org.seleniumhq.selenium/selenium-java "2.46.0"]
-                        [org.seleniumhq.selenium/selenium-remote-driver "2.46.0"]
+                        [org.seleniumhq.selenium/selenium-remote-driver "2.47.1"]
                         [org.seleniumhq.selenium/selenium-server "2.46.0"]]
 
          :plugins [[jonase/eastwood "0.2.1"]


### PR DESCRIPTION
org.seleniumhq.selenium/selenium-remote-driver 2.47.1 has been released. 

This pull request is created on behalf of @nbeloglazov
