### PR TITLE
Update org.clojure/clojurescript to 1.7.48 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
                  [commons-io "2.4"]
 
                  ; ClojureScript
-                 [org.clojure/clojurescript "1.7.28"]
+                 [org.clojure/clojurescript "1.7.48"]
                  [jayq "2.5.4"]
                  [org.omcljs/om "0.9.0"]]
 


### PR DESCRIPTION
org.clojure/clojurescript 1.7.48 has been released. 

This pull request is created on behalf of @nbeloglazov
