### PR TITLE
Update com.taoensso/timbre to 4.1.0 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  [ring/ring-json "0.4.0"]
                  [clj-http "2.0.0"]
                  [tentacles "0.4.0"]
-                 [com.taoensso/timbre "4.1.0-alpha2"]
+                 [com.taoensso/timbre "4.1.0"]
                  [com.novemberain/monger "3.0.0"]
                  [ancient-clj "0.3.10"]
                  [com.draines/postal "1.11.3"]


### PR DESCRIPTION
com.taoensso/timbre 4.1.0 has been released. 

This pull request is created on behalf of @nbeloglazov
