### PR TITLE
Update org.seleniumhq.selenium/selenium-server to 2.47.2 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -44,7 +44,7 @@
                         [com.cemerick/piggieback "0.2.1"]
                         [org.seleniumhq.selenium/selenium-java "2.47.1"]
                         [org.seleniumhq.selenium/selenium-remote-driver "2.47.1"]
-                        [org.seleniumhq.selenium/selenium-server "2.47.1"]]
+                        [org.seleniumhq.selenium/selenium-server "2.47.2"]]
 
          :plugins [[jonase/eastwood "0.2.1"]
                    [com.keminglabs/cljx "0.5.0" :exclusions [org.clojure/clojure]]]


### PR DESCRIPTION
org.seleniumhq.selenium/selenium-server 2.47.2 has been released. 

This pull request is created on behalf of @nbeloglazov
